### PR TITLE
Fixed 'Cannot GET' error for API routes

### DIFF
--- a/src/api/search.js
+++ b/src/api/search.js
@@ -4,28 +4,13 @@ var express2 = defaultConvert(express);
 var bing = require("bing.search");
 var bing2 = defaultConvert(bing);
 
+var search = new bing2.default("v2saqfFSvffL5FWI36G4lTvq6Bx/StC74MEtd/yy7CA");
 var searchHistory = require("../models/searchHistory");
 
 function defaultConvert(obj) {
   return obj && obj.__esModule ? obj : { default: obj };
 }
 
-var search = new bing2.default("v2saqfFSvffL5FWI36G4lTvq6Bx/StC74MEtd/yy7CA");
-var searchApi = exports.searchApi = express2.default.Router();
-
-searchApi.get("/search/:query", function (req, res) {
-  var query = req.params.query;
-  var offset = req.query.offset || 10;
-  var timestamp = Date.now();
-
-  search.images(query, function (error, results) {
-    if (error) {
-      res.status(500).json(error);
-    } else {
-      res.status(200).json(results.map(createResults));
-    }
-  });
-  
 function createResults(image) {
   return {
     url: image.url,
@@ -36,12 +21,34 @@ function createResults(image) {
   };
 }
 
-  var queryHistory = new searchHistory.SearchHistory({ query: query, timestamp: timestamp });
-  queryHistory.save();
-});
+module.exports = app => {
+  app.get("/search/:query", function (req, res) {
+    // WARNING with this URL => Returns empty JSON
+    var query = req.params.query;
+    var offset = req.query.offset || 10;
+    var timestamp = Date.now();
 
-searchApi.get("/latest", function (req, res) {
-  searchHistory.SearchHistory.find().select({ _id: 0, query: 1, timestamp: 1 }).sort({ timestamp: -1 }).limit(10).then(function (results) {
-    res.status(200).json(results);
+    search.images(query, function (error, results) {
+      if (error) {
+        res.status(500).json(error);
+      } else {
+        var queryHistory = new searchHistory.SearchHistory({ query: query, timestamp: timestamp });
+        queryHistory.save();
+        
+        res.status(200).json(results.map(createResults));
+      }
+    });
   });
-});
+
+  app.get("/latest", function (req, res) {
+    // ERROR with this URL => Never reaches 'then' in Promise
+    searchHistory.SearchHistory.find()
+      .select({ _id: 0, query: 1, timestamp: 1 })
+      .sort({ timestamp: -1 })
+      .limit(10)
+      .then(function (results) {
+        console.log(`Here are the results: ${results}`);
+        res.status(200).json(results);
+      });
+  });
+};

--- a/src/app.js
+++ b/src/app.js
@@ -5,14 +5,12 @@ var search = require("./api/search");
 var mongodb = process.env.MONGODB_URI || "mongodb://http://localhost:8080/";
 mongooseInit(mongodb);
 
-var searchApi = express.Router();
-
 function mongooseInit(mongodb) {
   mongoose.Promise = global.Promise;
   mongoose.connect(mongodb);
 };
 
 var app = express();
-app.use("/api", searchApi); 
+search(app);
 
 module.exports = app;


### PR DESCRIPTION
Removed call to express.Router()

Moved routes to something along the lines of -> 

```js
const app = express();

app.get('/someURL/:someParam', someFunction);
```